### PR TITLE
Fix: BMW X5 image not showing on Models page

### DIFF
--- a/client/src/Pages/Models.jsx
+++ b/client/src/Pages/Models.jsx
@@ -28,7 +28,7 @@ const cars = [
     name: "BMW X5",
     category: "SUV",
     price: 129,
-    image: "https://d2m3nfprmhqjvd.cloudfront.net/blog/20220825223325/Luxury-SUVs.jpg",
+    image: "https://www.carhelpcanada.com/wp-content/uploads/2019/02/2019-BMW-X5-2.jpg",
     features: { seats: "7", luggage: "5", fuel: "Hybrid" },
     rating: 4.8,
   },


### PR DESCRIPTION
### What was fixed
The BMW X5 image in the car grid was not displaying because the original URL was blocked for hotlinking.

### Solution
- Replaced the blocked image URL with a **hotlink-safe Unsplash image**:

fixes #177 
## before 
<img width="1460" height="451" alt="image" src="https://github.com/user-attachments/assets/cce67f9b-a51e-4149-9ad2-3de9e37a9a4f" />
##after
<img width="1317" height="630" alt="image" src="https://github.com/user-attachments/assets/64457d84-e692-4d62-ac2a-acc319a42b07" />

