### PR TITLE
fixed the overlapping Lastest model card in mobile screens

### DIFF
--- a/client/src/components/home/Hero.jsx
+++ b/client/src/components/home/Hero.jsx
@@ -142,7 +142,7 @@ const Hero = () => {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.5 }}
-            className="absolute bottom-4 -right-4 bg-white dark:bg-zinc-900 p-6 rounded-xl shadow-2xl border border-transparent dark:border-zinc-800 transition-all">
+           className="static lg:absolute lg:mt-6 lg:bottom-4 lg:-right-4 bg-white dark:bg-zinc-900 p-6 rounded-xl shadow-2xl border border-transparent dark:border-zinc-800 transition-all">
             <div className="flex items-center gap-3">
               <div className="p-2 bg-orange-100 dark:bg-orange-900/20 rounded-lg">
                 <Car className="text-orange-500 w-8 h-8" />


### PR DESCRIPTION
# Related Issue
Fixes:  #187


# Description

fixed the overlapping Lastest model card which was overlapping with the image of the car

issue number: #187 

# Type of PR
Bug fix


# Screenshots 

<img width="565" height="760" alt="image" src="https://github.com/user-attachments/assets/b2214970-441d-470b-ba32-b44a85e4d682" />


# Checklist:


- [x] I have made this change from my own.
- [x] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.