### PR TITLE
Fix: Hide Custom Cursor on Mobile & Handle WebGL Crashes gracefully

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -29,6 +29,9 @@ function App() {
   const [themeCounter, setThemeCounter] = useState(0);
   const [stateMap, setStateMap] = useState({ alpha: 1, beta: 2, gamma: 3 });
   const [loadTimestamp, setLoadTimestamp] = useState(Date.now());
+  
+  // New state to track screen size for MouseTrail
+  const [isLargeScreen, setIsLargeScreen] = useState(window.innerWidth >= 1024);
 
   const refContainer = useRef({ mounted: false, count: 0 });
 
@@ -68,6 +71,17 @@ function App() {
   }), [sessionFlag, computeValue, loadTimestamp, stateMap]);
 
   // ---------------- SIDE EFFECTS ----------------
+  
+  // Handle Screen Resize for MouseTrail
+  useEffect(() => {
+    const handleResize = () => {
+      setIsLargeScreen(window.innerWidth >= 1024);
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
   useEffect(() => {
     if (window.chatbase) return;
 
@@ -118,7 +132,12 @@ function App() {
   return (
     <div className={dynamicClasses}>
       <ScrollToTop />
-      <MouseTrail strokeColor="#F97316" lineWidthStart={30} />
+      
+      {/* Conditionally render MouseTrail only if screen is large enough */}
+      {isLargeScreen && (
+        <MouseTrail strokeColor="#F97316" lineWidthStart={30} />
+      )}
+
       <AnimatePresence mode="wait">
         <Routes>
           {/* ---------------- AUTH ROUTES ---------------- */}

--- a/client/src/components/home/Car3DModel.jsx
+++ b/client/src/components/home/Car3DModel.jsx
@@ -244,17 +244,25 @@ function Car3DModel() {
     camera.position.set(cameraPos.x, cameraPos.y, cameraPos.z);
     cameraRef.current = camera;
 
-    // Renderer setup with shadows
-    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-    renderer.setSize(containerRef.current.clientWidth, containerRef.current.clientHeight);
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-    renderer.setClearColor(0x000000, 0);
-    renderer.shadowMap.enabled = true;
-    renderer.shadowMap.type = THREE.PCFSoftShadowMap;
-    renderer.toneMapping = THREE.ACESFilmicToneMapping;
-    renderer.toneMappingExposure = 1.2;
-    containerRef.current.appendChild(renderer.domElement);
-    rendererRef.current = renderer;
+    // Renderer setup with shadows - WRAPPED IN TRY/CATCH TO PREVENT CRASH
+    let renderer;
+    try {
+      renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+      renderer.setSize(containerRef.current.clientWidth, containerRef.current.clientHeight);
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+      renderer.setClearColor(0x000000, 0);
+      renderer.shadowMap.enabled = true;
+      renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+      renderer.toneMapping = THREE.ACESFilmicToneMapping;
+      renderer.toneMappingExposure = 1.2;
+      containerRef.current.appendChild(renderer.domElement);
+      rendererRef.current = renderer;
+    } catch (e) {
+      console.error("WebGL is not supported or disabled:", e);
+      setHasError(true);
+      setIsLoading(false);
+      return; // Exit useEffect to prevent further errors
+    }
 
     // Lights - USE STATE VALUES
     const hemisphereLight = new THREE.HemisphereLight(0xffffff, 0x444444, lighting.ambient);


### PR DESCRIPTION
PR Description:
This PR addresses two critical issues to improve User Experience (UX) and application stability:

Mobile/Tablet UX Improvement (Issue #230):

**Problem: The custom cursor (Mouse Trail) was visible on mobile devices, degrading the UX. Simply hiding it with CSS caused calculation errors and crashes on some devices.**

_Solution: Implemented Conditional Rendering in App.jsx. The MouseTrail component now only mounts if the screen width is 1024px or larger (Desktop/Laptop). This improves performance and prevents mobile crashes._

3D Model WebGL Crash Fix:

**Problem: On browsers or devices without WebGL support (or if hardware acceleration is disabled), the Car3DModel component would crash the entire application, resulting in a black screen (White Screen of Death).**

_Solution: Added a try...catch block around the WebGL renderer initialization in Car3DModel.jsx. If WebGL fails, the app now gracefully catches the error and displays the Fallback Image instead of crashing._

Changes Made:

- client/src/App.jsx:
- Added isLargeScreen state to track window size.
- Wrapped <MouseTrail /> in a conditional check {isLargeScreen && ...}.
- client/src/components/home/Car3DModel.jsx:
- Wrapped new THREE.WebGLRenderer(...) in a try...catch block.
- Sets hasError state to true if initialization fails, triggering the fallback UI.

Testing:

- Mobile View: Verified that the custom cursor does not appear and the app loads without errors.
- Desktop View: Verified that the cursor appears and functions correctly.
- WebGL Failure: Tested by disabling WebGL in browser settings; confirmed that the 3D model is replaced by the static car image without crashing the app.

<img width="492" height="384" alt="image" src="https://github.com/user-attachments/assets/2b6fc21b-86ff-4702-8aa4-549ed23061bf" />

**If WebGL Fails like this:**
<img width="708" height="379" alt="image" src="https://github.com/user-attachments/assets/d4faf124-9fc6-4642-9868-320c0fb52612" />

**No Problem It will Load Static this img ( As A fallback Function Like 3d Model Fails To load , then No Problem rander Img Works On all Device Increase Performance of website  )** 
<img width="525" height="308" alt="image" src="https://github.com/user-attachments/assets/76d97845-d4fb-4bed-ac8b-21db0135f5a6" />


Closes #230  