### PR TITLE
fix: map search suggestions hidden behind leaflet map

### DIFF
--- a/client/src/Pages/Booking.jsx
+++ b/client/src/Pages/Booking.jsx
@@ -265,7 +265,7 @@ const BookingMap = ({ location, setLocation }) => {
         {suggestions.length > 0 && (
           <ul
             ref={suggestionsRef}
-            className="absolute top-full left-0 right-0 bg-white dark:bg-zinc-800 border border-gray-300 dark:border-zinc-700 rounded-b-lg max-h-40 overflow-auto z-50 shadow-lg"
+            className="absolute top-full left-0 right-0 bg-white dark:bg-zinc-800 border border-gray-300 dark:border-zinc-700 rounded-b-lg max-h-40 overflow-auto shadow-lg z-[9999]"
           >
             {suggestions.map((s, idx) => (
               <li


### PR DESCRIPTION
## Related Issue
Fixes #<258>

## Description
On the booking page, the location search autocomplete suggestions
were being rendered behind the Leaflet map due to z-index stacking.

This PR fixes the issue by increasing the z-index of the suggestions
dropdown so it consistently appears above the map and remains
fully visible and clickable.

## Type of PR
- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): __________

## Screenshots / Videos
<img width="1140" height="705" alt="Screenshot 2026-01-05 142158" src="https://github.com/user-attachments/assets/34e71b17-3fca-4732-949f-0f5094950e5b" />



## Checklist
- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.