### PR TITLE
Scroll to top button

### DIFF
--- a/client/src/components/ScrollToTop.jsx
+++ b/client/src/components/ScrollToTop.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { ArrowUp } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
-
+//Scroll to top button
 const ScrollToTop = () => {
     const { pathname } = useLocation();
     const [isVisible, setIsVisible] = useState(false);


### PR DESCRIPTION
# Related Issue
Scroll-up button missing at the bottom of the page

Fixes:  #268 

# Description

When users scroll down to the footer of the page, there is no scroll-up button available. This makes it inconvenient for users to quickly return to the top of the page or navigate back to the navbar.


# Type of PR

- [✅ ] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
<img width="1919" height="961" alt="image" src="https://github.com/user-attachments/assets/2b5eecd3-b0ae-420e-b238-0333a9f46cbe" />


# Checklist:

- [✅] I have made this change from my own.
- [ ✅] I have taken help from some online resources.
- [✅ ] My code follows the style guidelines of this project.
- [✅ ] I have performed a self-review of my own code.
- [✅ ] I have commented my code, particularly in hard-to-understand areas.
- [ ✅] I have made corresponding changes to the documentation.
- [ ✅] My changes generate no new warnings.
- [ ✅] I have tested the changes thoroughly before submitting this pull request.
- [ ✅] I have provided relevant issue numbers and screenshots after making the changes.